### PR TITLE
readme: Fixed wireshark plugin directory hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Also check out some of the [samples][samples].
 
 Grab the bootstrapped `wssdl.lua` from the [latest release][latest],
 and put it in your Wireshark Plugin directory
-(usually ~/.config/wireshark/plugins or /usr/lib/wireshark/<version>)
+(usually ~/.wireshark/plugins or /usr/lib/wireshark/<version>)
 
 ### From source
 


### PR DESCRIPTION
According to the [documentation], the user plugin directory resides
at `~/.wireshark/plugins/`.

[documentation]: https://www.wireshark.org/docs/wsug_html_chunked/ChAppFilesConfigurationSection.html